### PR TITLE
Fix Ubuntu multistage builds

### DIFF
--- a/ubuntu/Dockerfile.acemq
+++ b/ubuntu/Dockerfile.acemq
@@ -15,7 +15,6 @@ RUN go test -v ./cmd/runaceserver/
 RUN go test -v ./internal/...
 RUN go vet ./cmd/... ./internal/...
 
-FROM ubuntu:16.04 as aceinstall
 ARG ACE_INSTALL=ace-11.0.0.2.tar.gz
 WORKDIR /opt/ibm
 COPY deps/$ACE_INSTALL .
@@ -36,7 +35,7 @@ ADD https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/
 RUN chmod +x /usr/local/bin/kubectl && \
     /usr/local/bin/kubectl version --client
 
-COPY --from=aceinstall /opt/ibm/ace-11 /opt/ibm/ace-11
+COPY --from=builder /opt/ibm/ace-11 /opt/ibm/ace-11
 
 RUN /opt/ibm/ace-11/ace make registry global accept license silently
 

--- a/ubuntu/Dockerfile.aceonly
+++ b/ubuntu/Dockerfile.aceonly
@@ -15,7 +15,6 @@ RUN go test -v ./cmd/runaceserver/
 RUN go test -v ./internal/...
 RUN go vet ./cmd/... ./internal/...
 
-FROM ubuntu:16.04 as aceinstall
 ARG ACE_INSTALL=ace-11.0.0.2.tar.gz
 WORKDIR /opt/ibm
 COPY deps/$ACE_INSTALL .
@@ -34,7 +33,7 @@ ADD https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/
 RUN chmod +x /usr/local/bin/kubectl && \
     /usr/local/bin/kubectl version --client
 
-COPY --from=aceinstall /opt/ibm/ace-11 /opt/ibm/ace-11
+COPY --from=builder /opt/ibm/ace-11 /opt/ibm/ace-11
 
 RUN /opt/ibm/ace-11/ace make registry global accept license silently
 


### PR DESCRIPTION
The Ubuntu builds didn't work on my workstation. I was able to fix this by removing the usage of the ubuntu:16.04 image and performing the unpacking of the ACE package in the golang image. This also improves the build time, because it now only uses 2 images.