### PR TITLE
Handle spaces in setdbparms

### DIFF
--- a/sample/initial-config/setdbparms/setdbparms.txt
+++ b/sample/initial-config/setdbparms/setdbparms.txt
@@ -1,3 +1,3 @@
 # resource user password
-setdbparms::truststore dummy truststorepwd
-mqsisetdbparms -w /home/aceuser/ace-server -n salesforce::SecurityIdentity -u myUsername -p myPassword -c myClientID -s myClientSecret
+setdbparms::truststore "my username" truststorepwd
+mqsisetdbparms -w /home/aceuser/ace-server -n salesforce::SecurityIdentity -u "my username" -p myPassword -c myClientID -s myClientSecret

--- a/ubi/Dockerfile.acemq
+++ b/ubi/Dockerfile.acemq
@@ -52,7 +52,7 @@ COPY LICENSE /licenses/licensing.txt
 
 WORKDIR /opt/ibm
 
-RUN microdnf install --nodocs openssl util-linux unzip && microdnf clean all
+RUN microdnf install --nodocs openssl util-linux unzip python2 && microdnf clean all
 COPY --from=builder /opt/ibm/ace-11 /opt/ibm/ace-11
 RUN /opt/ibm/ace-11/ace make registry global accept license silently
 

--- a/ubi/Dockerfile.aceonly
+++ b/ubi/Dockerfile.aceonly
@@ -47,7 +47,7 @@ COPY /licenses/ /licenses/
 
 WORKDIR /opt/ibm
 
-RUN microdnf install --nodocs openssl util-linux unzip && microdnf clean all
+RUN microdnf install --nodocs openssl util-linux unzip python2 && microdnf clean all
 COPY --from=builder /opt/ibm/ace-11 /opt/ibm/ace-11
 RUN /opt/ibm/ace-11/ace make registry global accept license silently
 


### PR DESCRIPTION
This updates enables quoted strings to be used in the setdbparms.txt file. 

This works for both the old and the new mechanism of supplying credentials 

Resolves https://github.com/ot4i/ace-docker/issues/61

Output of container with new code when using the sample setdbparms file. 

```
2019-07-16T08:02:01.409Z Image created: 2019-07-09T16:13:02+00:00
2019-07-16T08:02:01.410Z Image revision: Not specified
2019-07-16T08:02:01.410Z Image source: Not specified
2019-07-16T08:02:01.698Z ACE version: 11005
2019-07-16T08:02:01.698Z ACE level: S000-L190627.15920
2019-07-16T08:02:01.698Z ACE build type: Production, 64 bit, amd64_linux_2
2019-07-16T08:02:01.698Z Checking for valid working directory
2019-07-16T08:02:01.698Z Checking if work dir is already initialized
2019-07-16T08:02:01.698Z Checking for contents in the work dir
2019-07-16T08:02:01.698Z Work dir initialization complete
2019-07-16T08:02:01.698Z Performing initial configuration of integration server
2019-07-16T08:02:01.698Z No content server url available
2019-07-16T08:02:01.701Z Processing configuration in folder setdbparms
2019-07-16T08:02:01.712Z+00:00 Handling setdbparms configuration
2019-07-16T08:02:01.767Z+00:00 Setting user and password for resource: setdbparms::truststore
BIP8071I: Successful command completion.
2019-07-16T08:02:01.863Z+00:00 BIP8071I: Successful command completion. 
2019-07-16T08:02:01.865Z+00:00 Running suppplied mqsisetdbparms command
2019-07-16T08:02:01.954Z+00:00 BIP8071I: Successful command completion. 
2019-07-16T08:02:01.955Z+00:00 setdbparms configuration complete
2019-07-16T08:02:01.956Z Initial configuration of integration server complete
2019-07-16T08:02:01.956Z Discovering override ports
2019-07-16T08:02:01.965Z Successfully discovered override ports
2019-07-16T08:02:01.965Z Starting integration server
2019-07-16T08:02:01.965Z No default application name supplied. Using the integration server name instead.
2019-07-16T08:02:01.965Z Waiting for integration server to be ready
2019-07-16T08:02:01.969Z Integration server not ready yet
.....2019-07-16 08:02:02.179184: .2019-07-16 08:02:02.180805: Integration server 'ACESERVER' starting initialization; version '11.0.0.5' (64-bit) 
..........................................2019-07-16 08:02:05.590932: IBM App Connect Enterprise administration security is inactive. 
2019-07-16 08:02:05.649753: The HTTP Listener has started listening on port '7600' for 'RestAdmin http' connections. 

2019-07-16 08:02:05.655024: Integration server has finished initialization. 
2019-07-16T08:02:06.974Z Integration server is ready
2019-07-16T08:02:06.974Z Metrics are disabled
```

Evidence the parameters have been imported correctly

```
[aceuser@7a92f2d16c33 ~]$   . /opt/ibm/ace-11/server/bin/mqsiprofile && mqsireportdbparms -w /home/aceuser/ace-server -n salesforce::SecurityIdentity

MQSI 11.0.0.5
/opt/ibm/ace-11/server

BIP8180I: The resource name 'salesforce::SecurityIdentity' has userID 'my username'. 
BIP8209I: The resource name 'salesforce::SecurityIdentity' has client identity 'myClientID'. 
BIP8210I: The resource name 'salesforce::SecurityIdentity' has client secret 'myClientSecret'. 

BIP8071I: Successful command completion. 
[aceuser@7a92f2d16c33 ~]$ mqsireportdbparms -w /home/aceuser/ace-server -n setdbparms::truststore      
BIP8180I: The resource name 'setdbparms::truststore' has userID 'my username'. 

BIP8071I: Successful command completion. 

```