### PR TITLE
Removed the delete of /var/mqm from the mq install script

### DIFF
--- a/ubi/install-mq.sh
+++ b/ubi/install-mq.sh
@@ -57,6 +57,3 @@ find /opt/mqm -name '*.tar.gz' -delete
 
 # Clean up all the downloaded files
 rm -rf ${DIR_EXTRACT}
-
-# Remove the directory structure under /var/mqm which was created by the installer
-rm -rf /var/mqm


### PR DESCRIPTION

- Found that the ACE MQ client image requires the contents of the /var/mqm folder to run an ACE flow with an MQ node.

Resolves issue https://github.com/ot4i/ace-docker/issues/59