### PR TITLE
Updates for 11.0.0.6.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change log
 
+## 11.0.0.6.1 (2019-11-20)
+
+**Breaking changes**:
+* None
+
+**Other changes**:
+* Updated kubectl to version v1.16.0
+* Updated MQ to version 9.1.3.0-r3
+* Added support for hostname and port overrides when routes are defined
+* Created ACE roles for five different access levels: admin, operator, viewer, editor, and audit
+
 ## 11.0.0.6 (2019-10-30)
 
 **Breaking changes**:

--- a/README.md
+++ b/README.md
@@ -199,25 +199,55 @@ You can mount the following file structure at `/home/aceuser/initial-config`. Mi
    - The truststore file that will be created for these files needs a password. You must set a truststore password using the environment variable `ACE_TRUSTSTORE_PASSWORD`
    - You can place multiple files, each with a different file name/alias.
 - `/home/aceuser/initial-config/webusers`
-   - A text file called either `admin-users.txt` or `operator-users.txt`. It contains a list of users to be created as admin/operator users using the command `mqsiwebuseradmin`. These users will have READ, WRITE and EXECUTE access on the Integration Server. The file has the following format:
+   - A text file called `admin-users.txt`. It contains a list of users to be created as `admin` users using the command `mqsiwebuseradmin`. These users will have READ, WRITE and EXECUTE access on the Integration Server. The file has the following format:
      ```
      # Lines starting with a "#" are ignored
-     # Each line should specify the <adminUser> <password>, separated by a single space
+     # Each line should specify the <user> <password>, separated by a single space
      # Each user will have "READ", "WRITE" and "EXECUTE" access on the integration server
      # Each line will be processed by calling...
-     #   mqsiwebuseradmin -w /home/aceuser/ace-server -c -u <adminUser> -a <password> -r admin
+     #   mqsiwebuseradmin -w /home/aceuser/ace-server -c -u <user> -a <password> -r admin
      admin1 password1
      admin2 password2
      ```
-   - A text file called `viewer-users.txt`, `editor-users.txt`, `audit-users.txt` . It contains a list of users to be created as viewer/editor/auditor users using the command `mqsiwebuseradmin`. These users will have READ access on the Integration Server. The file has the following format:
+     - A text file called `operator-users.txt`. It contains a list of users to be created as `operator` users using the command `mqsiwebuseradmin`. These users will have READ and EXECUTE access on the Integration Server. The file has the following format:
      ```
      # Lines starting with a "#" are ignored
-     # Each line should specify the <adminUser> <password>, separated by a single space
+     # Each line should specify the <user> <password>, separated by a single space
+     # Each user will have "READ" and "EXECUTE" access on the integration server
+     # Each line will be processed by calling...
+     #   mqsiwebuseradmin -w /home/aceuser/ace-server -c -u <user> -a <password> -r operator
+     operator1 password1
+     operator2 password2
+     ```
+     - A text file called `editor-users.txt`. It contains a list of users to be created as `editor` users using the command `mqsiwebuseradmin`. These users will have READ and WRITE access on the Integration Server. The file has the following format:
+     ```
+     # Lines starting with a "#" are ignored
+     # Each line should specify the <user> <password>, separated by a single space
+     # Each user will have "READ" and "WRITE" access on the integration server
+     # Each line will be processed by calling...
+     #   mqsiwebuseradmin -w /home/aceuser/ace-server -c -u <user> -a <password> -r editor
+     editor1 password1
+     editor2 password2
+     ```
+     - A text file called `audit-users.txt`. It contains a list of users to be created as `audit` users using the command `mqsiwebuseradmin`. These users will have READ access on the Integration Server. The file has the following format:
+     ```
+     # Lines starting with a "#" are ignored
+     # Each line should specify the <user> <password>, separated by a single space
      # Each user will have "READ" access on the integration server
      # Each line will be processed by calling...
-     #   mqsiwebuseradmin -w /home/aceuser/ace-server -c -u <adminUser> -a <password> -r viewer
-     admin1 password1
-     admin2 password2
+     #   mqsiwebuseradmin -w /home/aceuser/ace-server -c -u <user> -a <password> -r audit
+     audit1 password1
+     audit2 password2
+     ```
+     - A text file called `viewer-users.txt`. It contains a list of users to be created as `viewer` users using the command `mqsiwebuseradmin`. These users will have READ access on the Integration Server. The file has the following format:
+     ```
+     # Lines starting with a "#" are ignored
+     # Each line should specify the <user> <password>, separated by a single space
+     # Each user will have "READ" access on the integration server
+     # Each line will be processed by calling...
+     #   mqsiwebuseradmin -w /home/aceuser/ace-server -c -u <user> -a <password> -r viewer
+     viewer1 password1
+     viewer2 password2
      ```
 - `/home/aceuser/initial-config/mqsc`
    - A text file called `config.mqsc`. It contains a list of mqsc commands which will be processed on start by `runmqsc` command. Further details can be found in the [MQ Knowledge Center](https://www.ibm.com/support/knowledgecenter/en/SSFKSJ_9.1.0/com.ibm.mq.adm.doc/q020670_.htm)

--- a/ace_discover_port_overrides.sh
+++ b/ace_discover_port_overrides.sh
@@ -1,6 +1,11 @@
 #!/bin/bash -ex
-
-if ! [[ -z "${KUBERNETES_PORT}" ]] && ! [[ -z "${SERVICE_NAME}" ]] ; then
+if ! [[ -z "${ACE_HTTP_ROUTE_NAME}" ]] && [[ "${ACE_ENDPOINT_TYPE}" = 'http' ]]; then
+  echo "export MQSI_OVERRIDE_HTTP_PORT=80" >> /home/aceuser/portOverrides
+  echo "export MQSI_OVERRIDE_HOSTNAME=$(kubectl get route ${ACE_HTTP_ROUTE_NAME} -o jsonpath=\"{.status.ingress[0].host}\")" >> /home/aceuser/portOverrides
+elif ! [[ -z "${ACE_HTTPS_ROUTE_NAME}" ]] && [[ "${ACE_ENDPOINT_TYPE}" = 'https' ]]; then
+  echo "export MQSI_OVERRIDE_HTTPS_PORT=443" >> /home/aceuser/portOverrides
+  echo "export MQSI_OVERRIDE_HOSTNAME=$(kubectl get route ${ACE_HTTPS_ROUTE_NAME} -o jsonpath=\"{.status.ingress[0].host}\")" >> /home/aceuser/portOverrides
+elif ! [[ -z "${KUBERNETES_PORT}" ]] && ! [[ -z "${SERVICE_NAME}" ]] ; then
   echo "export MQSI_OVERRIDE_HTTP_PORT=$(kubectl get svc ${SERVICE_NAME} -o jsonpath=\"{.spec.ports[1].nodePort}\")" >> /home/aceuser/portOverrides
   echo "export MQSI_OVERRIDE_HTTPS_PORT=$(kubectl get svc ${SERVICE_NAME} -o jsonpath=\"{.spec.ports[2].nodePort}\")" >> /home/aceuser/portOverrides
 fi

--- a/ace_integration_server.sh
+++ b/ace_integration_server.sh
@@ -15,7 +15,9 @@ if [ -s /home/aceuser/ace-server/odbc.ini ]; then
   export ODBCINI=/home/aceuser/ace-server/odbc.ini
 fi
 
-if ! [[ -z "${KUBERNETES_PORT}" ]] && ! [[ -z "${SERVICE_NAME}" ]] ; then
+if ! [[ -z "${ACE_HTTP_ROUTE_NAME}" ]] || ! [[ -z "${ACE_HTTPS_ROUTE_NAME}" ]] ; then
+  . /home/aceuser/portOverrides
+elif ! [[ -z "${KUBERNETES_PORT}" ]] && ! [[ -z "${SERVICE_NAME}" ]] ; then
   . /home/aceuser/portOverrides
 fi
 

--- a/experimental/README.md
+++ b/experimental/README.md
@@ -12,4 +12,4 @@ To run the sample after building:
 
 docker run -e LICENSE=accept --rm -ti ace-sample-alpine
 
-and then curl http://IP_address_of_container:7800/test should return '{"data":"a string from ACE"}'
+and then curl http://<container IP>:7800/test should return '{"data":"a string from ACE"}'

--- a/ubi/Dockerfile.acemq
+++ b/ubi/Dockerfile.acemq
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ibmcom/mq:9.1.3.0
+ARG BASE_IMAGE=ibmcom/mq:9.1.3.0-r3
 
 FROM golang:1.10.3 as builder
 
@@ -69,7 +69,7 @@ COPY --from=builder /go/src/github.com/ot4i/ace-docker/chkace* /usr/local/bin/
 # Copy in script files
 COPY *.sh /usr/local/bin/
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 RUN chmod +x /usr/local/bin/kubectl && \
     /usr/local/bin/kubectl version --client
 

--- a/ubi/Dockerfile.aceonly
+++ b/ubi/Dockerfile.aceonly
@@ -63,7 +63,7 @@ COPY --from=builder /go/src/github.com/ot4i/ace-docker/chkace* /usr/local/bin/
 # Copy in script files
 COPY *.sh /usr/local/bin/
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.12.9/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 RUN chmod +x /usr/local/bin/kubectl && \
     /usr/local/bin/kubectl version --client
 

--- a/ubi/Dockerfile.mqclient
+++ b/ubi/Dockerfile.mqclient
@@ -3,7 +3,7 @@ ARG BASE_IMAGE=ibmcom/ace
 FROM $BASE_IMAGE
 
 # The MQ packages to install - see install-mq.sh for default value
-ARG MQ_URL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev912_linux_x86-64.tar.gz"
+ARG MQ_URL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev913_linux_x86-64.tar.gz"
 ARG MQ_URL_USER
 ARG MQ_URL_PASS
 ARG MQ_PACKAGES="MQSeriesRuntime*.rpm MQSeriesJava*.rpm MQSeriesGSKit*.rpm MQSeriesClient*.rpm"


### PR DESCRIPTION
The features for this PR includes:

- Updated kubectl to version v1.16.0
- Updated MQ to version 9.1.3.0-r3
- Added support for hostname and port overrides when routes are defined
- Created ACE roles for five different access levels: admin, operator, viewer, editor, and audit