### PR TITLE
feat(zCX): Add support for zCX from FP8

### DIFF
--- a/experimental/ace-minimal-install/Dockerfile.ubuntu
+++ b/experimental/ace-minimal-install/Dockerfile.ubuntu
@@ -44,6 +44,6 @@ RUN apt-get install -y zip binutils && \
     find /opt/ibm -name "*.lil" -exec strip {} ";" && \
     ( strip /opt/ibm/ace-11/server/bin/* 2>/dev/null || /bin/true ) && \
     zip -d /opt/ibm/ace-11/common/classes/IntegrationAPI.jar BIPmsgs_de.properties BIPmsgs_es.properties BIPmsgs_fr.properties BIPmsgs_it.properties BIPmsgs_ja.properties BIPmsgs_ko.properties BIPmsgs_pl.properties BIPmsgs_pt_BR.properties BIPmsgs_ru.properties BIPmsgs_tr.properties BIPmsgs_zh.properties BIPmsgs_zh_HK.properties BIPmsgs_zh_TW.properties && \
-    apt-get remove -y zip binutils binutils-common binutils-x86-64-linux-gnu libbinutils && \
+    if [ $(uname -m) = x86_64 ]; then apt-get remove -y zip binutils binutils-common libbinutils binutils-x86-64-linux-gnu; else apt-get remove -y zip binutils binutils-common libbinutils; fi && \
     /opt/ibm/ace-11/ace make registry global accept license deferred
  


### PR DESCRIPTION
Make the changes needed so that s390x images can be built from experimental using FP8 (tested on both zLinux and zCX). No changes made to the ubi build as FP8 requires ubi8 and this doesn't currently work on zCX - in discussion with the zCX team and will submit a further PR once this is addressed.

Changed files:
   - experimental/ace-minimal-install/Dockerfile.ubuntu - remove arch dependency to allow to run on platforms other than x86

Contributes to Cloud-Integration/ace-build-and-test-pipeline/issues/334

Signed-off-by: Alison Lucas <alisonb@uk.ibm.com>