### PR TITLE
feat(zCX): Add ubi support for zCX from FP8

### DIFF
--- a/ace_config_keystore.sh
+++ b/ace_config_keystore.sh
@@ -22,6 +22,11 @@ if ls /home/aceuser/initial-config/keystore/*.key >/dev/null 2>&1; then
   fi
 
   IFS=$'\n'
+  KEYTOOL=/opt/ibm/ace-11/common/jdk/jre/bin/keytool
+  if [ ! -f "$KEYTOOL" ]; then
+    KEYTOOL=/opt/ibm/ace-11/common/jre/bin/keytool
+  fi
+
   for keyfile in `ls /home/aceuser/initial-config/keystore/*.key`; do
     if [ -s "${keyfile}" ]; then
       if [ -z "${ACE_KEYSTORE_PASSWORD}" ]; then
@@ -48,7 +53,7 @@ if ls /home/aceuser/initial-config/keystore/*.key >/dev/null 2>&1; then
       fi
       logAndExitIfError $? "${OUTPUT}"
 
-      OUTPUT=$(/opt/ibm/ace-11/common/jdk/jre/bin/keytool -importkeystore -srckeystore /home/aceuser/ace-server/keystore.p12 -destkeystore /home/aceuser/ace-server/keystore.jks -srcstorepass ${ACE_KEYSTORE_PASSWORD} -deststorepass ${ACE_KEYSTORE_PASSWORD} -srcalias ${alias} -destalias ${alias} -srcstoretype PKCS12 -noprompt 2>&1)
+      OUTPUT=$(${KEYTOOL} -importkeystore -srckeystore /home/aceuser/ace-server/keystore.p12 -destkeystore /home/aceuser/ace-server/keystore.jks -srcstorepass ${ACE_KEYSTORE_PASSWORD} -deststorepass ${ACE_KEYSTORE_PASSWORD} -srcalias ${alias} -destalias ${alias} -srcstoretype PKCS12 -noprompt 2>&1)
       logAndExitIfError $? "${OUTPUT}"
 
       OUTPUT=$(rm /home/aceuser/ace-server/keystore.p12 2>&1)

--- a/ace_config_truststore.sh
+++ b/ace_config_truststore.sh
@@ -22,6 +22,10 @@ if ls /home/aceuser/initial-config/truststore/*.crt >/dev/null 2>&1; then
   fi
 
   IFS=$'\n'
+  KEYTOOL=/opt/ibm/ace-11/common/jdk/jre/bin/keytool
+  if [ ! -f "$KEYTOOL" ]; then
+    KEYTOOL=/opt/ibm/ace-11/common/jre/bin/keytool
+  fi
   for file in `ls /home/aceuser/initial-config/truststore/*.crt`; do
     if [ -s "${file}" ]; then
       if [ -z "${ACE_TRUSTSTORE_PASSWORD}" ]; then
@@ -31,7 +35,7 @@ if ls /home/aceuser/initial-config/truststore/*.crt >/dev/null 2>&1; then
 
       filename=$(basename $file)
       alias=$(echo $filename | sed -e 's/\.crt$'//)
-      OUTPUT=$(/opt/ibm/ace-11/common/jdk/jre/bin/keytool -importcert -trustcacerts -alias ${filename} -file ${file} -keystore /home/aceuser/ace-server/truststore.jks -storepass ${ACE_TRUSTSTORE_PASSWORD} -noprompt 2>&1)
+      OUTPUT=$(${KEYTOOL} -importcert -trustcacerts -alias ${filename} -file ${file} -keystore /home/aceuser/ace-server/truststore.jks -storepass ${ACE_TRUSTSTORE_PASSWORD} -noprompt 2>&1)
       logAndExitIfError $? "${OUTPUT}"
     fi
   done

--- a/experimental/ace-minimal-install/Dockerfile.ubuntu
+++ b/experimental/ace-minimal-install/Dockerfile.ubuntu
@@ -44,6 +44,6 @@ RUN apt-get install -y zip binutils && \
     find /opt/ibm -name "*.lil" -exec strip {} ";" && \
     ( strip /opt/ibm/ace-11/server/bin/* 2>/dev/null || /bin/true ) && \
     zip -d /opt/ibm/ace-11/common/classes/IntegrationAPI.jar BIPmsgs_de.properties BIPmsgs_es.properties BIPmsgs_fr.properties BIPmsgs_it.properties BIPmsgs_ja.properties BIPmsgs_ko.properties BIPmsgs_pl.properties BIPmsgs_pt_BR.properties BIPmsgs_ru.properties BIPmsgs_tr.properties BIPmsgs_zh.properties BIPmsgs_zh_HK.properties BIPmsgs_zh_TW.properties && \
-    apt-get remove -y zip binutils binutils-common binutils-x86-64-linux-gnu libbinutils && \
+    if [ $(uname -m) = x86_64 ]; then apt-get remove -y zip binutils binutils-common libbinutils binutils-x86-64-linux-gnu; else apt-get remove -y zip binutils binutils-common libbinutils; fi && \
     /opt/ibm/ace-11/ace make registry global accept license deferred
  

--- a/ubi/Dockerfile.acemq
+++ b/ubi/Dockerfile.acemq
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=ibmcom/mq:9.1.3.0-r3
+ARG BASE_IMAGE=ibmcom/mq:9.1.4.0-r1
 
 FROM golang:1.10.3 as builder
 
@@ -16,7 +16,7 @@ RUN go test -v ./cmd/runaceserver/
 RUN go test -v ./internal/...
 RUN go vet ./cmd/... ./internal/...
 
-ARG ACE_INSTALL=ace-11.0.0.5.tar.gz
+ARG ACE_INSTALL=ace-11.0.0.8.tar.gz
 WORKDIR /opt/ibm
 COPY deps/$ACE_INSTALL .
 RUN mkdir ace-11
@@ -37,7 +37,7 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="$PRODNAME-$COMPNAME" \
       name="$PRODNAME/$COMPNAME" \
       vendor="IBM" \
-      version="11.0.0.6" \
+      version="11.0.0.8" \
       release="1" \
       license="IBM" \
       maintainer="Hybrid Integration Platform Cloud" \
@@ -57,7 +57,7 @@ COPY deps/OpenTracing/config/* ./etc/ACEOpenTracing/
 
 WORKDIR /opt/ibm
 
-RUN microdnf install --nodocs openssl util-linux unzip python2 && microdnf clean all
+RUN microdnf install openssl util-linux unzip python2 && microdnf clean all
 RUN microdnf update
 COPY --from=builder /opt/ibm/ace-11 /opt/ibm/ace-11
 RUN /opt/ibm/ace-11/ace make registry global accept license silently
@@ -69,9 +69,10 @@ COPY --from=builder /go/src/github.com/ot4i/ace-docker/chkace* /usr/local/bin/
 # Copy in script files
 COPY *.sh /usr/local/bin/
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl /usr/local/bin/kubectl
-RUN chmod +x /usr/local/bin/kubectl && \
-    /usr/local/bin/kubectl version --client
+# Install kubernetes cli
+COPY ubi/install-kubectl.sh /usr/local/bin/
+RUN chmod u+x /usr/local/bin/install-kubectl.sh \
+  && install-kubectl.sh
 
 # Create the ace workdir for user mqm, and chmod script files
 RUN mkdir /home/aceuser \

--- a/ubi/Dockerfile.aceonly
+++ b/ubi/Dockerfile.aceonly
@@ -14,13 +14,13 @@ RUN go test -v ./cmd/runaceserver/
 RUN go test -v ./internal/...
 RUN go vet ./cmd/... ./internal/...
 
-ARG ACE_INSTALL=ace-11.0.0.2.tar.gz
+ARG ACE_INSTALL=ace-11.0.0.8.tar.gz
 WORKDIR /opt/ibm
 COPY deps/$ACE_INSTALL .
 RUN mkdir ace-11
 RUN tar -xzf $ACE_INSTALL --absolute-names --exclude ace-11.\*/tools --strip-components 1 --directory /opt/ibm/ace-11
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 ENV SUMMARY="Integration Server for App Connect Enterprise" \
     DESCRIPTION="Integration Server for App Connect Enterprise" \
@@ -35,7 +35,7 @@ LABEL summary="$SUMMARY" \
       com.redhat.component="$PRODNAME-$COMPNAME" \
       name="$PRODNAME/$COMPNAME" \
       vendor="IBM" \
-      version="11.0.0.6" \
+      version="11.0.0.8" \
       release="1" \
       license="IBM" \
       maintainer="Hybrid Integration Platform Cloud" \
@@ -52,7 +52,7 @@ COPY deps/OpenTracing/config/* ./etc/ACEOpenTracing/
 
 WORKDIR /opt/ibm
 
-RUN microdnf install --nodocs openssl util-linux unzip python2 && microdnf clean all
+RUN microdnf install findutils openssl util-linux unzip python2 && microdnf clean all
 COPY --from=builder /opt/ibm/ace-11 /opt/ibm/ace-11
 RUN /opt/ibm/ace-11/ace make registry global accept license silently
 
@@ -63,9 +63,10 @@ COPY --from=builder /go/src/github.com/ot4i/ace-docker/chkace* /usr/local/bin/
 # Copy in script files
 COPY *.sh /usr/local/bin/
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl /usr/local/bin/kubectl
-RUN chmod +x /usr/local/bin/kubectl && \
-    /usr/local/bin/kubectl version --client
+# Install kubernetes cli
+COPY ubi/install-kubectl.sh /usr/local/bin/
+RUN chmod u+x /usr/local/bin/install-kubectl.sh \
+  && install-kubectl.sh
 
 # Create a user to run as, create the ace workdir, and chmod script files
 RUN useradd -u 1000 -d /home/aceuser -G mqbrkrs,wheel aceuser \

--- a/ubi/install-kubectl.sh
+++ b/ubi/install-kubectl.sh
@@ -16,17 +16,14 @@
 # limitations under the License.
 
 # Fail on any non-zero return code
-set -ex
+set -e
 
-test -f /usr/bin/microdnf && MICRODNF=true || MICRODNF=false
-test -f /usr/bin/rpm && RPM=true || RPM=false
-
-if ($RPM); then
-  EXTRA_RPMS="findutils ca-certificates curl tar"
-  $MICRODNF && microdnf install ${EXTRA_RPMS}
+# Download kubectl
+if [[ $(uname -m) == s390x ]]
+then
+  curl -s -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/s390x/kubectl
 else
-  $MICRODNF && microdnf install findutils
+   curl -s -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl
 fi
-
-# Clean up cached files
-$MICRODNF && microdnf clean all
+chmod +x /usr/local/bin/kubectl && \
+    /usr/local/bin/kubectl version --client


### PR DESCRIPTION
Make the changes needed so that s390x images can be built using FP8 (tested on zLinux). For zCX this requires APAR OA59111 to be applied which should be available 3Q.

Changed:
   - ace_config_keystore.sh - not all platforms ship the full jdk so allow for this when setting path to keytool executable 
   - ace_config_truststore.sh - as for ace_config_keystore.sh
   - ubi/Dockerfile.aceonly
      - upgrade to ubi8 to support fix pack 8 - ubi8 has a bug with microdnf nodocs option (https://bugzilla.redhat.com/show_bug.cgi?id=1784427) so removed nodocs from microdnf commands, and added a findutils install as that is not in ubi8 either (needed for ace make)
      - change to use install-kubectl.sh script to install appropriate version of kubectl binary
   - ubi/Dockerfile.acemq
      -  upgrade to 9.1.4.0-r1 to get ubi8 and remove nodocs option as above
      - change to use install-kubectl.sh script to install appropriate version of kubectl binary
   - ubi/install-mq-client-prereqs.sh
      - ubi8 does not contain the find command so install findutils here so it can be used in install-mq.sh processing
      - also removed nodocs option from microdnf as above

New:
   - ubi/install-kubectl.sh - script to install the appropriate architecture’s kubectl binary - since zCX doesn’t yet support Kubernetes it seems pointless to install it’s cli there but zLinux does and there’s no way I’ve found to tell if you’re running in zCX or zLinux so I’ve left it in for zLinux. zCX should support it soon anyhow

Contributes to Cloud-Integration/ace-build-and-test-pipeline/issues/334

Signed-off-by: Alison Lucas <alisonb@uk.ibm.com>
