### PR TITLE
Add configurable vault key to the runaceserver command

### DIFF
--- a/internal/name/name.go
+++ b/internal/name/name.go
@@ -18,6 +18,8 @@ limitations under the License.
 package name
 
 import (
+	"fmt"
+	"io/ioutil"
 	"os"
 	"regexp"
 )
@@ -58,4 +60,28 @@ func GetIntegrationServerName() (string, error) {
 		name = sanitizeName(name)
 	}
 	return name, nil
+}
+
+// GetIntegrationServerVaultKey resolves the integration server Vault key to use.
+// If error, configuration was wrong.
+// If empty and no error, there was nothing configured.
+func GetIntegrationServerVaultKey() (string, error) {
+	var path string
+	var err error
+	path, ok := os.LookupEnv("ACE_VAULT_KEY_FILE")
+	if !ok || path == "" {
+		return "", nil
+	}
+	stat, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	if stat.IsDir() {
+		return "", fmt.Errorf("vault key file is a directory: %s", path)
+	}
+	bytes, readErr := ioutil.ReadFile(path)
+	if readErr != nil {
+		return "", readErr
+	}
+	return string(bytes), nil
 }


### PR DESCRIPTION
First of all, I'm very impressed with the quality of this repo. Thank you very much, that was fun starting ACE without any prior knowledge.

I have a Docker image where I want to pre-configure certain credentials before the integration server starts. I have noticed, currently, there is no way to pass the vault key to `runaceserver` command.

This PR adds support for a new environment variable called `ACE_VAULT_KEY_FILE`. When this variable contains a full path for the file, which contains a vault key string, the `runaceserver` command is going to validate that:

- the file exists
- the is not a directory

If the file exists and is a file, it reads the contents of the file and sets the `--vault-key` argument.

Caveats:

- `GetIntegrationServerVaultKey` is currently under the `name` package, this is most likely wrong; I would require an advice on where is a better place for this bit
- there are no tests, I can add them when the location for the `GetIntegrationServerVaultKey` is correct
- the readme would need an update

Would you be willing to accept this PR when the blanks mentioned above are filled in? Do you require any contributors agreement?

Thanks!