### PR TITLE
Define length limits on signal channels

### DIFF
--- a/cmd/runaceserver/signals.go
+++ b/cmd/runaceserver/signals.go
@@ -32,8 +32,8 @@ func signalHandler(shutdownFunc func()) chan int {
 	control := make(chan int)
 	// Use separate channels for the signals, to avoid SIGCHLD signals swamping
 	// the buffer, and preventing other signals.
-	stopSignals := make(chan os.Signal)
-	reapSignals := make(chan os.Signal)
+	stopSignals := make(chan os.Signal, 2)
+	reapSignals := make(chan os.Signal, 2)
 	signal.Notify(stopSignals, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		for {


### PR DESCRIPTION
<!-- Only raise a PR if it's ready to be merged/reviewed.-->
<!-- Please include a link to the Epic or issue-->
## Relevant issue, Epic or stories.
https://github.com/ot4i/ace-docker/issues/164

<!-- PR's without a description will be closed-->
## Description of what this PR accomplishes and why it's needed

A recent update to golang means that it now fails to lint/compile when the `os.Signal` channel is used without a buffer length limit.  We aren't signal-heavy and should only see one each of `SIGTERM`/`SIGKILL` so a short buffer length should suffice

## How Has This Been Tested?

Have seen this build break in our internal builds, and seen this change resolve the build failure
