### PR TITLE
Allow mq client on Z

### DIFF
--- a/ubi/Dockerfile.mqclient
+++ b/ubi/Dockerfile.mqclient
@@ -8,12 +8,14 @@ USER root
 ARG MQ_URL
 ARG MQ_URL_USER
 ARG MQ_URL_PASS
+ARG MQ_PACKAGES="MQSeriesRuntime*.rpm MQSeriesJava*.rpm MQSeriesJRE*.rpm MQSeriesGSKit*.rpm MQSeriesClient*.rpm"
 ARG INSTALL_JRE=1
 
 COPY ubi/install-mq.sh /usr/local/bin/
 COPY ubi/install-mq-client-prereqs.sh /usr/local/bin/
+COPY ubi/create-default-mq-kdb.sh /usr/local/bin/
 # Install MQ.  To avoid a "text file busy" error here, we sleep before installing.
-RUN chmod u+x /usr/local/bin/install-*.sh \
+RUN chmod u+x /usr/local/bin/install-*.sh /usr/local/bin/create-*.sh \
   && sleep 1 \
   && install-mq-client-prereqs.sh \
   && install-mq.sh \
@@ -21,7 +23,7 @@ RUN chmod u+x /usr/local/bin/install-*.sh \
 
 RUN . /opt/ibm/ace-12/server/bin/mqsiprofile \
       && echo $MQSI_JREPATH \
-      && /opt/mqm/bin/runmqckm -keydb -convert -db $MQSI_JREPATH/lib/security/cacerts -old_format jks -new_format kdb -pw changeit -target /tmp/mqcacerts.kdb -stash
+      && /usr/local/bin/create-default-mq-kdb.sh
 
 # This is to delete any flash files which some customers consider a vulnerability - mostly used by googlelibs
 RUN echo "Removing the following swf files" \
@@ -36,6 +38,7 @@ USER root
 ARG MQ_URL
 ARG MQ_URL_USER
 ARG MQ_URL_PASS
+ARG MQ_PACKAGES="MQSeriesRuntime*.rpm MQSeriesJava*.rpm MQSeriesJRE*.rpm MQSeriesGSKit*.rpm MQSeriesClient*.rpm"
 ARG INSTALL_JRE=0
 
 ARG MQM_UID=888
@@ -60,6 +63,7 @@ ENV AMQ_DIAGNOSTIC_MSG_SEVERITY=1 AMQ_ADDITIONAL_JSON_LOG=1
 # Set the integration server to use it by default. A user provided server.conf.yaml will override this behaviour if the mqKeyRepository property is set.
 RUN mkdir /home/aceuser/truststores
 COPY --from=truststore-builder /tmp/mqcacerts.kdb /home/aceuser/truststores/mqcacerts.kdb
+COPY --from=truststore-builder /tmp/mqcacerts.sth /home/aceuser/truststores/mqcacerts.sth
 RUN chmod -R 777 /home/aceuser/truststores \
   && sed -i 's/#.*mqKeyRepository:.*/mqKeyRepository: \/home\/aceuser\/truststores\/mqcacerts/g' /home/aceuser/ace-server/server.conf.yaml
 

--- a/ubi/create-default-mq-kdb.sh
+++ b/ubi/create-default-mq-kdb.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# -*- mode: sh -*-
+# © Copyright IBM Corporation 2022
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fail on any non-zero return code
+set -ex
+
+
+if [ -f "/opt/mqm/bin/runmqckm" ]
+then
+  # 
+  # Used if the downloaded package is the MQ client package from FixCentral. Example URL:
+  #  
+  # https://ak-delivery04-mul.dhe.ibm.com/sdfdl/v2/sar/CM/WS/0a3ih/0/Xa.2/Xb.jusyLTSp44S0BnrSUlhcQXsmOX33PXiMu_opTWF4XkF7jFZV8UxrP0RFSE0/Xc.CM/WS/0a3ih/0/9.2.0.4-IBM-MQC-LinuxX64.tar.gz/Xd./Xf.LPR.D1VK/Xg.11634360/Xi.habanero/XY.habanero/XZ.m7uIgNXpo_VTCGzC-hylOC79m0eKS5pi/9.2.0.4-IBM-MQC-LinuxX64.tar.gz
+  # 
+  # Also used if the downloaded package is the full MQ developer package. Example URL:
+  #
+  # https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev924_linux_x86-64.tar.gz
+  #
+  echo "Using runmqckm to create default MQ kdb from Java cacerts"
+  /opt/mqm/bin/runmqckm -keydb -convert -db $MQSI_JREPATH/lib/security/cacerts -old_format jks -new_format kdb -pw changeit -target /tmp/mqcacerts.kdb -stash
+else
+  # 
+  # Used if the downloaded package is the MQ redistributable client. Example URL:
+  # 
+  # https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.2.0.4-IBM-MQC-Redist-LinuxX64.tar.gz
+  #
+  echo "Did not find runmqckm; using keytool and runmqakm to create default MQ kdb from Java cacerts"
+  $MQSI_JREPATH/bin/keytool -importkeystore -srckeystore $MQSI_JREPATH/lib/security/cacerts -srcstorepass changeit -destkeystore /tmp/java-cacerts.p12 -deststoretype pkcs12 -deststorepass changeit 
+  /opt/mqm/bin/runmqakm -keydb -convert -db /tmp/java-cacerts.p12 -old_format p12 -new_format kdb -pw changeit -target /tmp/mqcacerts.kdb -stash
+fi
+

--- a/ubi/install-mq.sh
+++ b/ubi/install-mq.sh
@@ -18,7 +18,7 @@
 # Fail on any non-zero return code
 set -ex
 
-# Download and extract the MQ unzippable files
+# Download and extract the MQ files
 DIR_TMP=/tmp/mq
 mkdir -p ${DIR_TMP}
 cd ${DIR_TMP}
@@ -32,38 +32,80 @@ tar -xzf ./*.tar.gz
 rm -f ./*.tar.gz
 ls -la ${DIR_TMP}
 
-# Generate MQ package in INSTALLATION_DIR
-export genmqpkg_inc32=0
-export genmqpkg_incadm=1
-export genmqpkg_incamqp=0
-export genmqpkg_incams=0
-export genmqpkg_inccbl=0
-export genmqpkg_inccics=0
-export genmqpkg_inccpp=1
-export genmqpkg_incdnet=0
-export genmqpkg_incjava=1
-export genmqpkg_incjre=${INSTALL_JRE}
-export genmqpkg_incman=0
-export genmqpkg_incmqbc=0
-export genmqpkg_incmqft=0
-export genmqpkg_incmqsf=0
-export genmqpkg_incmqxr=0
-export genmqpkg_incnls=0
-export genmqpkg_incras=1
-export genmqpkg_incsamp=0
-export genmqpkg_incsdk=0
-export genmqpkg_incserver=0
-export genmqpkg_inctls=1
-export genmqpkg_incunthrd=0
-export genmqpkg_incweb=0
-export INSTALLATION_DIR=/opt/mqm
-${DIR_TMP}/bin/genmqpkg.sh -b ${INSTALLATION_DIR}
-ls -la ${INSTALLATION_DIR}
-rm -rf ${DIR_TMP}
+# Check what sort of MQ package was downloaded
+if [ -f "${DIR_TMP}/bin/genmqpkg.sh" ]
+then 
+  # Generate MQ package in INSTALLATION_DIR
+  # 
+  # Used if the downloaded package is the MQ redistributable client. Example URL:
+  #    
+  # https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.2.0.4-IBM-MQC-Redist-LinuxX64.tar.gz
+  #
+  echo "Detected genmqpkg.sh; installing MQ client components"
+  export genmqpkg_inc32=0
+  export genmqpkg_incadm=1
+  export genmqpkg_incamqp=0
+  export genmqpkg_incams=0
+  export genmqpkg_inccbl=0
+  export genmqpkg_inccics=0
+  export genmqpkg_inccpp=1
+  export genmqpkg_incdnet=0
+  export genmqpkg_incjava=1
+  export genmqpkg_incjre=${INSTALL_JRE}
+  export genmqpkg_incman=0
+  export genmqpkg_incmqbc=0
+  export genmqpkg_incmqft=0
+  export genmqpkg_incmqsf=0
+  export genmqpkg_incmqxr=0
+  export genmqpkg_incnls=0
+  export genmqpkg_incras=1
+  export genmqpkg_incsamp=0
+  export genmqpkg_incsdk=0
+  export genmqpkg_incserver=0
+  export genmqpkg_inctls=1
+  export genmqpkg_incunthrd=0
+  export genmqpkg_incweb=0
+  export INSTALLATION_DIR=/opt/mqm
+  
+  # Install requested parts
+  ${DIR_TMP}/bin/genmqpkg.sh -b ${INSTALLATION_DIR}
+  ls -la ${INSTALLATION_DIR}
 
-# Accept the MQ license
-${INSTALLATION_DIR}/bin/mqlicense -accept
+  # Accept the MQ license
+  ${INSTALLATION_DIR}/bin/mqlicense -accept
+else
+  # Check if should try install using RPM
+  test -f /usr/bin/rpm && RPM=true || RPM=false
+  if [ ! $RPM ]; then
+    echo "Did not find the rpm command; cannot continue MQ client install without rpm"
+    exit 9
+  fi
+  # 
+  # Used if the downloaded package is the MQ client package from FixCentral. Example URL:
+  #    
+  # https://ak-delivery04-mul.dhe.ibm.com/sdfdl/v2/sar/CM/WS/0a3ih/0/Xa.2/Xb.jusyLTSp44S0BnrSUlhcQXsmOX33PXiMu_opTWF4XkF7jFZV8UxrP0RFSE0/Xc.CM/WS/0a3ih/0/9.2.0.4-IBM-MQC-LinuxX64.tar.gz/Xd./Xf.LPR.D1VK/Xg.11634360/Xi.habanero/XY.habanero/XZ.m7uIgNXpo_VTCGzC-hylOC79m0eKS5pi/9.2.0.4-IBM-MQC-LinuxX64.tar.gz
+  # 
+  # Also used if the downloaded package is the full MQ developer package. Example URL:
+  #
+  # https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqadv/mqadv_dev924_linux_x86-64.tar.gz
+  #
+  echo "Did not find genmqpkg.sh; installing MQ client components using rpm"
+  $RPM && DIR_RPM=$(find ${DIR_TMP} -name "*.rpm" -printf "%h\n" | sort -u | head -1)
+
+  # Find location of mqlicense.sh
+  MQLICENSE=$(find ${DIR_TMP} -name "mqlicense.sh")
+  
+  # Accept the MQ license
+  ${MQLICENSE} -text_only -accept
+
+  # Install MQ using the rpm packages
+  $RPM && cd $DIR_RPM && rpm -ivh $MQ_PACKAGES
+
+  # Remove tar.gz files unpacked by RPM postinst scripts
+  find /opt/mqm -name '*.tar.gz' -delete
+fi
+
+rm -rf ${DIR_TMP}
 
 # Create the directory for MQ configuration files
 install --directory --mode 2775 --owner 1001 --group root /etc/mqm
-


### PR DESCRIPTION
## Description of what this PR accomplishes and why it's needed
The scripts have been updated to allow the MQ full image (only instal…ling the client parts), the MQ client image, and also the MQ redistributable client (cut-down free package). This requires different installation methods and also different key management.

## How Has This Been Tested?
Manual testing on xLinux with all three package options, and zLinux with the MQ client image (no redistributable on zLinux) by @TDOLBY and @ALISONB

Link to ot4i-ace-docker test build: https://appcon-jenkins.swg-devops.com/view/ACEcc%20-%20Operand%20Builds/job/ot4i-ace-docker/job/allowMQClientOnZ/
