### PR TITLE
Bump version to 12.0.4 and remove git.commit files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Build and run:
 #
-# docker build -t ace:12.0.2.0 -f Dockerfile .
-# docker run -e LICENSE=accept -p 7600:7600 -p 7800:7800 --rm -ti ace:12.0.2.0
+# docker build -t ace:12.0.4.0 -f Dockerfile .
+# docker run -e LICENSE=accept -p 7600:7600 -p 7800:7800 --rm -ti ace:12.0.4.0
 #
 # Can also mount a volume for the work directory:
 #
-# docker run -e LICENSE=accept -v /what/ever/dir:/home/aceuser/ace-server -p 7600:7600 -p 7800:7800 --rm -ti ace:12.0.2.0
+# docker run -e LICENSE=accept -v /what/ever/dir:/home/aceuser/ace-server -p 7600:7600 -p 7800:7800 --rm -ti ace:12.0.4.0
 #
 # This might require a local directory with the right permissions, or changing the userid further down . . .
 
@@ -15,7 +15,7 @@ RUN microdnf update && microdnf install util-linux curl tar
 
 ARG USERNAME
 ARG PASSWORD
-ARG DOWNLOAD_URL=http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/integration/12.0.2.0-ACE-LINUX64-DEVELOPER.tar.gz
+ARG DOWNLOAD_URL=http://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/integration/12.0.4.0-ACE-LINUX64-DEVELOPER.tar.gz
 
 RUN mkdir -p /opt/ibm/ace-12 \
     && if [ -z $USERNAME ]; then curl ${DOWNLOAD_URL}; else curl -u "${USERNAME}:${PASSWORD}" ${DOWNLOAD_URL}; fi | \
@@ -38,14 +38,12 @@ RUN microdnf reinstall tzdata -y
 # Prevent errors about having no terminal when using apt-get
 ENV DEBIAN_FRONTEND noninteractive
 
-# Install ACE v12.0.2.0 and accept the license
+# Install ACE v12.0.4.0 and accept the license
 COPY --from=builder /opt/ibm/ace-12 /opt/ibm/ace-12
 RUN /opt/ibm/ace-12/ace make registry global accept license deferred \
     && useradd --uid 1001 --create-home --home-dir /home/aceuser --shell /bin/bash -G mqbrkrs aceuser \
     && su - aceuser -c "export LICENSE=accept && . /opt/ibm/ace-12/server/bin/mqsiprofile && mqsicreateworkdir /home/aceuser/ace-server" \
     && echo ". /opt/ibm/ace-12/server/bin/mqsiprofile" >> /home/aceuser/.bashrc
-
-COPY git.commit* /home/aceuser/
 
 # Add required license as text file in Liceses directory (GPL, MIT, APACHE, Partner End User Agreement, etc)
 COPY /licenses/ /licenses/


### PR DESCRIPTION
ACE 12.0.4 is the latest available.

Signed-off-by: Trevor Dolby <trevor.dolby@ibm.com>